### PR TITLE
Fix unknown instruction bytes due to O3 optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ OBJS = $(addprefix $(OBJ_DIR)/, $(SRCS:.c=.o))
 DEBUG_OBJS = $(addprefix $(OBJ_DIR)/debug/, $(SRCS:.c=.o))
 
 HEADERS = $(wildcard $(INC_DIR)/*.h) $(wildcard $(LIBFT_DIR)/src/**/*.h)
+
+LIBFT_SRCS = $(shell find $(LIBFT_DIR) -name "*.c")
+LIBFT_HEADERS = $(shell find $(LIBFT_DIR) -name "*.h")
+
 LIBFT = $(LIBFT_DIR)/libft.a
 LIBFT_FLAGS = -L$(LIBFT_DIR) -lft
 
@@ -35,7 +39,7 @@ $(NAME): $(OBJS) $(LIBFT) | $(INC_DIR)/constants.h
 $(INC_DIR)/constants.h: codegen/constants.h scripts/encode.py
 	python3 scripts/encode.py codegen/constants.h > $(INC_DIR)/constants.h
 
-$(LIBFT):
+$(LIBFT): $(LIBFT_SRCS) $(LIBFT_HEADERS)
 	$(MAKE) -C $(LIBFT_DIR)
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c $(HEADERS) | $(OBJ_DIR)

--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,11 @@ $(OBJ_DIR):
 	mkdir -p $(OBJ_DIR)/
 
 clean:
+	$(MAKE) -C $(LIBFT_DIR) clean
 	rm -rf $(OBJ_DIR)
 
 fclean: clean
+	$(MAKE) -C $(LIBFT_DIR) fclean
 	rm -f $(NAME) $(PAYLOAD_NAME)
 
 re: fclean all


### PR DESCRIPTION
`-O3` in `libft` was using `avx512` instructions, which valgrind did not recognize. This is actually not really an issue, since the process was still running correctly (only killed by valgrind), but better safe than sorry.

Also fixed the dependencies in the Makefile, was not rebuilding on changes in `libft`.